### PR TITLE
eth_gasPrice

### DIFF
--- a/pkg/eth/rpc_types.go
+++ b/pkg/eth/rpc_types.go
@@ -364,6 +364,10 @@ func (r *GetFilterChangesRequest) UnmarshalJSON(data []byte) error {
 
 type EstimateGasResponse string
 
+// ========== eth_gasPrice ============= //
+
+type GasPriceResponse *ETHInt
+
 // ========== eth_getBlockByNumber ============= //
 
 type (

--- a/pkg/qtum/method.go
+++ b/pkg/qtum/method.go
@@ -69,6 +69,11 @@ func (m *Method) GetBlockCount() (resp *GetBlockCountResponse, err error) {
 	return
 }
 
+// hard coded for now as there is only the minimum gas price
+func (m *Method) GetGasPrice() (*big.Int, error) {
+	return big.NewInt(0x28), nil
+}
+
 func (m *Method) GetBlockHash(b *big.Int) (resp GetBlockHashResponse, err error) {
 	req := GetBlockHashRequest{
 		Int: b,

--- a/pkg/transformer/eth_gasPrice.go
+++ b/pkg/transformer/eth_gasPrice.go
@@ -1,0 +1,32 @@
+package transformer
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/qtumproject/janus/pkg/eth"
+	"github.com/qtumproject/janus/pkg/qtum"
+)
+
+// ProxyETHEstimateGas implements ETHProxy
+type ProxyETHGasPrice struct {
+	*qtum.Qtum
+}
+
+func (p *ProxyETHGasPrice) Method() string {
+	return "eth_gasPrice"
+}
+
+func (p *ProxyETHGasPrice) Request(rawreq *eth.JSONRPCRequest) (interface{}, error) {
+	qtumresp, err := p.Qtum.GetGasPrice()
+	if err != nil {
+		return nil, err
+	}
+
+	// qtum res -> eth res
+	return p.response(qtumresp), nil
+}
+
+func (p *ProxyETHGasPrice) response(qtumresp *big.Int) string {
+	return hexutil.EncodeBig(qtumresp)
+}

--- a/pkg/transformer/transformer.go
+++ b/pkg/transformer/transformer.go
@@ -101,6 +101,7 @@ func DefaultProxies(qtumRPCClient *qtum.Qtum) []ETHProxy {
 		&ProxyETHGetBalance{Qtum: qtumRPCClient},
 		&Web3ClientVersion{},
 		&ProxyETHSign{Qtum: qtumRPCClient},
+		&ProxyETHGasPrice{Qtum: qtumRPCClient},
 	}
 }
 


### PR DESCRIPTION
adds the method eth_gasPrice. This enables us to go further into Bancor integrations as their tests use this method. For now it's just a hardcode of the minimal gas price. Depends on the previous PR. 