### PR TITLE
Dehardcode the gas limit and have it come purely from the transaction

### DIFF
--- a/pkg/transformer/util.go
+++ b/pkg/transformer/util.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/qtumproject/janus/pkg/eth"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 	"github.com/qtumproject/janus/pkg/utils"
@@ -16,14 +18,7 @@ type EthGas interface {
 }
 
 func EthGasToQtum(g EthGas) (gasLimit *big.Int, gasPrice string, err error) {
-	gasLimit = big.NewInt(40000000)
-	if gas := g.GasHex(); gas != "" {
-		gasLimit, err = utils.DecodeBig(gas)
-		if err != nil {
-			err = errors.Wrap(err, "decode gas")
-			return
-		}
-	}
+	gasLimit = g.(*eth.SendTransactionRequest).Gas.Int
 
 	gasPriceFloat64, err := EthValueToQtumAmount(g.GasPriceHex())
 	if err != nil {


### PR DESCRIPTION
This PR is made because hardcoding the gas limit has caused issues while trying to test performance. Instead of doing that we can now take in gas as the requester has submitted in the transaction. We can evaluate whether or not to fix the gas price down the line but for the sake of ease, this is the best way to alleviate the problem in the moment. 
Signed-off-by: VoR0220 <catalanor0220@gmail.com>