### PR TITLE
Fix eth_getStorageAt to work with slots by index

### DIFF
--- a/pkg/transformer/eth_getStorageAt.go
+++ b/pkg/transformer/eth_getStorageAt.go
@@ -46,11 +46,14 @@ func (p *ProxyETHGetStorageAt) request(ethreq *qtum.GetStorageRequest, index str
 	return p.ToResponse(qtumresp, index), nil
 }
 
-func (p *ProxyETHGetStorageAt) ToResponse(qtumresp *qtum.GetStorageResponse, index string) *eth.GetStorageResponse {
+func (p *ProxyETHGetStorageAt) ToResponse(qtumresp *qtum.GetStorageResponse, slot string) *eth.GetStorageResponse {
 	// the value for unknown anything
 	storageData := eth.GetStorageResponse("0x0000000000000000000000000000000000000000000000000000000000000000")
+	if len(slot) != 64 {
+		slot = leftPadStringWithZerosTo64Bytes(slot)
+	}
 	for _, outerValue := range *qtumresp {
-		qtumStorageData, ok := outerValue[index]
+		qtumStorageData, ok := outerValue[slot]
 		if ok {
 			storageData = eth.GetStorageResponse(utils.AddHexPrefix(qtumStorageData))
 			return &storageData
@@ -58,4 +61,9 @@ func (p *ProxyETHGetStorageAt) ToResponse(qtumresp *qtum.GetStorageResponse, ind
 	}
 
 	return &storageData
+}
+
+// left pad a string with leading zeros to fit 64 bytes
+func leftPadStringWithZerosTo64Bytes(hex string) string {
+	return fmt.Sprintf("%064v", hex)
 }

--- a/pkg/transformer/eth_getStorageAt_test.go
+++ b/pkg/transformer/eth_getStorageAt_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/qtumproject/janus/pkg/qtum"
 )
 
-func TestGetStorageAtRequest(t *testing.T) {
+func TestGetStorageAtRequestWithNoLeadingZeros(t *testing.T) {
 	index := "abcde"
 	blockNumber := "0x1234"
 	requestParams := []json.RawMessage{[]byte(`"` + getTransactionByHashBlockNumber + `"`), []byte(`"0x` + index + `"`), []byte(`"` + blockNumber + `"`)}
@@ -24,8 +24,49 @@ func TestGetStorageAtRequest(t *testing.T) {
 	value := "0x012341231441234123412343211234abcde12342332100000223030004005000"
 
 	getStorageResponse := qtum.GetStorageResponse{}
-	getStorageResponse["12345"] = make(map[string]string)
-	getStorageResponse["12345"][index] = value
+	getStorageResponse[leftPadStringWithZerosTo64Bytes("12345")] = make(map[string]string)
+	getStorageResponse[leftPadStringWithZerosTo64Bytes("12345")][leftPadStringWithZerosTo64Bytes(index)] = value
+	err = mockedClientDoer.AddResponseWithRequestID(2, qtum.MethodGetStorage, getStorageResponse)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//preparing proxy & executing request
+	proxyEth := ProxyETHGetStorageAt{qtumClient}
+	got, err := proxyEth.Request(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := eth.GetStorageResponse(value)
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf(
+			"error\ninput: %s\nwant: %s\ngot: %s",
+			request,
+			string(mustMarshalIndent(want, "", "  ")),
+			string(mustMarshalIndent(got, "", "  ")),
+		)
+	}
+}
+
+func TestGetStorageAtRequestWithLeadingZeros(t *testing.T) {
+	index := leftPadStringWithZerosTo64Bytes("abcde")
+	blockNumber := "0x1234"
+	requestParams := []json.RawMessage{[]byte(`"` + getTransactionByHashBlockNumber + `"`), []byte(`"0x` + index + `"`), []byte(`"` + blockNumber + `"`)}
+	request, err := prepareEthRPCRequest(1, requestParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockedClientDoer := newDoerMappedMock()
+	qtumClient, err := createMockedClient(mockedClientDoer)
+
+	value := "0x012341231441234123412343211234abcde12342332100000223030004005000"
+
+	getStorageResponse := qtum.GetStorageResponse{}
+	getStorageResponse[leftPadStringWithZerosTo64Bytes("12345")] = make(map[string]string)
+	getStorageResponse[leftPadStringWithZerosTo64Bytes("12345")][leftPadStringWithZerosTo64Bytes(index)] = value
 	err = mockedClientDoer.AddResponseWithRequestID(2, qtum.MethodGetStorage, getStorageResponse)
 	if err != nil {
 		t.Fatal(err)
@@ -66,8 +107,8 @@ func TestGetStorageAtUnknownFieldRequest(t *testing.T) {
 	value := "0x012341231441234123412343211234abcde12342332100000223030004005000"
 
 	getStorageResponse := qtum.GetStorageResponse{}
-	getStorageResponse["12345"] = make(map[string]string)
-	getStorageResponse["12345"][index] = value
+	getStorageResponse[leftPadStringWithZerosTo64Bytes("12345")] = make(map[string]string)
+	getStorageResponse[leftPadStringWithZerosTo64Bytes("12345")][leftPadStringWithZerosTo64Bytes(index)] = value
 	err = mockedClientDoer.AddResponseWithRequestID(2, qtum.MethodGetStorage, getStorageResponse)
 	if err != nil {
 		t.Fatal(err)
@@ -89,5 +130,29 @@ func TestGetStorageAtUnknownFieldRequest(t *testing.T) {
 			string(mustMarshalIndent(want, "", "  ")),
 			string(mustMarshalIndent(got, "", "  ")),
 		)
+	}
+}
+
+func TestLeftPadStringWithZerosTo64Bytes(t *testing.T) {
+	tests := make(map[string]string)
+
+	tests["1"] = "0000000000000000000000000000000000000000000000000000000000000001"
+	tests["01"] = "0000000000000000000000000000000000000000000000000000000000000001"
+	tests["001"] = "0000000000000000000000000000000000000000000000000000000000000001"
+	tests["1001"] = "0000000000000000000000000000000000000000000000000000000000001001"
+	tests["0000000000000000000000000000000000000000000000000000000000001001"] = "0000000000000000000000000000000000000000000000000000000000001001"
+	tests["1111111111111111111111111111111111111111111111111111111111111111"] = "1111111111111111111111111111111111111111111111111111111111111111"
+	tests["21111111111111111111111111111111111111111111111111111111111111111"] = "21111111111111111111111111111111111111111111111111111111111111111"
+
+	for input, expected := range tests {
+		result := leftPadStringWithZerosTo64Bytes(input)
+		if result != expected {
+			t.Errorf(
+				"error\ninput: %s\nwant: %s\ngot: %s",
+				input,
+				expected,
+				result,
+			)
+		}
 	}
 }


### PR DESCRIPTION
Fixes eth_getStorageAt when a slot is chosen by index, eg 0, 1, 2 etc
QTUM responds with these with zero prefixed 64 length hex strings, this just prefixes them before looking the values up in QTUM response