### PR TITLE
Add SSL support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,4 @@
 /testing
 /playground
 /metamask
-
+/https

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 build
 node_modules
 metamask/dist
+https
 
 # local env files
 .env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ ENV QTUM_NETWORK=regtest
 
 EXPOSE 23889
 
-ENTRYPOINT [ "janus"]
+ENTRYPOINT [ "janus" ]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Janus is and old school ETH web3 HTTP provider that translates Ethereum JSON RPC
 
 - [Requirements](#requirements)
 - [Installation](#installation)
+  - [SSL](#ssl)
+  - [Self-signed SSL](#self-signed-ssl)
 - [How to use Janus as a Web3 provider](#how-to-use-janus-as-a-web3-provider)
 - [How to add Janus to Metamask](#how-to-add-janus-to-metamask)
 - [Support ETH methods](#support-eth-methods)
@@ -49,6 +51,16 @@ Which will run the most current local version of Janus on port 23888, but withou
 Note that Janus will use the hex address for the test base58 Qtum addresses that belong the the local qtum node, for example:
   - qUbxboqjBRp96j3La8D1RYkyqx5uQbJPoW (hex 0x7926223070547d2d15b2ef5e7383e541c338ffe9 )
   - qLn9vqbr2Gx3TsVR9QyTVB5mrMoh4x43Uf (hex 0x2352be3db3177f0a07efbe6da5857615b8c9901d )
+
+### SSL
+SSL keys and certificates go inside the https folder (mounted at `/https` in the container) and use `--https-key` and `--https-cert` parameters. If the specified files do not exist, it will fall back to http.
+
+### Self-signed SSL
+To generate self-signed certificates with docker for local development the following script will generate SSL certificates and drop them into the https folder
+
+```
+$ make docker-configure-https
+```
 
 ## How to use Janus as a Web3 provider
 

--- a/docker/openssl.Dockerfile
+++ b/docker/openssl.Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:1.14-alpine
+
+RUN apk add --no-cache openssl

--- a/docker/quick_start/docker-compose.yml
+++ b/docker/quick_start/docker-compose.yml
@@ -13,9 +13,10 @@ services:
         - QTUM_RPC=http://qtum:testpasswd@qtum:3889
     volumes:
         - ../standalone/myaccounts.txt:$GOPATH/github.com/qtumproject/janus/myaccounts.txt
+        - ../../https:/https
     depends_on:
       - qtum
-    command: --bind 0.0.0.0 --accounts $GOPATH/github.com/qtumproject/janus/myaccounts.txt --dev
+    command: --bind 0.0.0.0 --accounts $GOPATH/github.com/qtumproject/janus/myaccounts.txt --dev --https-key /https/key.pem --https-cert /https/cert.pem
   qtum:
     ports:
       - "3889:3889"

--- a/docker/setup_self_signed_https.sh
+++ b/docker/setup_self_signed_https.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+if [ -f "./https/cert.pem" ]; then
+    echo "cert.pem already exists"
+    if [ ! -f "./https/key.pem" ]; then
+        echo "key.pem does not exist, both are needed, please delete "`pwd`"/https/key.pem manually"
+        exit 1
+    fi
+    exit 0
+fi
+
+mkdir -p ./https
+if [ ! -d "./https" ]; then
+    echo "Failed to mkdir -p ./https"
+    exit 1
+fi
+
+echo "Generating key.pem and cert.pem"
+docker run -v `pwd`/https:/https qtum/openssl.janus openssl req -nodes  -x509 -newkey rsa:4096 -keyout /https/key.pem -out /https/cert.pem -days 365 -subj "/C=US/ST=ST/L=L/O=Janus Self-signed https/OU=Janus Self-signed https/CN=Janus Self-signed https"
+if [ 0 -ne $? ]; then
+    echo "Failed to generate server.key"
+    exit $?
+fi
+
+if [ ! -r ./https/key.key ]; then
+    echo "Generated files have wrong owner, chowning them"
+    sudo chown `id -u`:`id -g` ./https/key.pem ./https/cert.pem
+    if [ ! -r ./https/key.pem ]; then
+        echo "Failed to chown on generated files, do it manually in "`pwd`"/https"
+        echo "\"sudo chown `id -u`:`id -g` ./https/key.pem ./https/cert.pem\""
+        exit 1
+    else
+        echo "Successfully chown'd generated files are now readable"
+    fi
+fi
+
+exit 0
+
+echo "Generating server.key"
+docker run -v `pwd`/https:/https qtum/openssl.janus openssl genrsa -out /https/server.key 2048
+if [ 0 -ne $? ]; then
+    echo "Failed to generate server.key"
+    exit $?
+fi
+docker run -v `pwd`/https:/https qtum/openssl.janus openssl ecparam -genkey -name secp384r1 -out /https/server.key
+if [ 0 -ne $? ]; then
+    echo "Failed to generate sever.key"
+    exit $?
+fi
+echo "Generating server.crt"
+docker run -v `pwd`/https:/https qtum/openssl.janus openssl req -nodes -new -x509 -sha256 -key /https/server.key -out /https/server.crt -days 3650 -subj "/C=US/ST=ST/L=L/O=Janus Self-signed https/OU=Janus Self-signed https/CN=Janus Self-signed https"
+if [ 0 -ne $? ]; then
+    echo "Failed to generate server.crt"
+    exit $?
+fi
+
+


### PR DESCRIPTION
wallet_addEthereumChain requires an ssl endpoint, so this is mainly for local development purposes