### PR TITLE
Alejo

### DIFF
--- a/pkg/transformer/eth_call.go
+++ b/pkg/transformer/eth_call.go
@@ -33,7 +33,7 @@ func (p *ProxyETHCall) request(ethreq *eth.CallRequest) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if qtumreq.GasLimit.Cmp(big.NewInt(40000000)) > 0 {
+	if qtumreq.GasLimit != nil && qtumreq.GasLimit.Cmp(big.NewInt(40000000)) > 0 {
 		qtumresp := eth.CallResponse("0x")
 		p.Qtum.GetLogger().Log("msg", "Caller gas above allowance, capping", "requested", qtumreq.GasLimit.Int64(), "cap", "40,000,000")
 		return &qtumresp, nil

--- a/pkg/transformer/eth_call.go
+++ b/pkg/transformer/eth_call.go
@@ -33,6 +33,10 @@ func (p *ProxyETHCall) request(ethreq *eth.CallRequest) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+	if qtumreq.GasLimit.Cmp(big.NewInt(25000000)) > 0 {
+		qtumresp := eth.CallResponse("0x")
+		return &qtumresp, nil
+	}
 
 	qtumresp, err := p.CallContract(qtumreq)
 	if err != nil {

--- a/pkg/transformer/eth_call.go
+++ b/pkg/transformer/eth_call.go
@@ -35,6 +35,7 @@ func (p *ProxyETHCall) request(ethreq *eth.CallRequest) (interface{}, error) {
 	}
 	if qtumreq.GasLimit.Cmp(big.NewInt(40000000)) > 0 {
 		qtumresp := eth.CallResponse("0x")
+		p.Qtum.GetLogger().Log("msg", "Caller gas above allowance, capping", "requested", qtumreq.GasLimit.Int64(), "cap", "40,000,000")
 		return &qtumresp, nil
 	}
 

--- a/pkg/transformer/eth_call.go
+++ b/pkg/transformer/eth_call.go
@@ -33,7 +33,7 @@ func (p *ProxyETHCall) request(ethreq *eth.CallRequest) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if qtumreq.GasLimit.Cmp(big.NewInt(25000000)) > 0 {
+	if qtumreq.GasLimit.Cmp(big.NewInt(40000000)) > 0 {
 		qtumresp := eth.CallResponse("0x")
 		return &qtumresp, nil
 	}

--- a/pkg/transformer/util.go
+++ b/pkg/transformer/util.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+	"strings"
 
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/qtumproject/janus/pkg/eth"
@@ -253,6 +254,9 @@ func getBlockNumberByParam(p *qtum.Qtum, param string, defaultVal bool) (*big.In
 		return nil, errors.New("TODO: tag is in implementation")
 
 	default: // hex number
+		if !strings.HasPrefix(param, "0x") {
+			return nil, errors.New("quantity values must start with 0x")
+		}
 		n, err := utils.DecodeBig(param)
 		if err != nil {
 			p.GetDebugLogger().Log("function", "getBlockNumberByParam", "msg", "Failed to decode hex parameter", "value", param)


### PR DESCRIPTION
**1. This PR implements the following 2 fixes on Janus**

- Cap on `gasLimit > 40M` on `eth_call` 
- Hex format verification in block numbers on `eth_getLogs` 

For further details see below

**2. Fix: Cap on gasLimit**
- Janus behaviour before the fix (when receiving RPC call with gasLimit=50M)

```
level=debug component=qtum.Client method=callcontract
=> qtum RPC request
{
  "jsonrpc": "1.0",
  "method": "callcontract",
  "id": "1",
  "params": [
    "1d670185fc3f7f3ee9008ce4966e9bad8f780b39",
    "18160ddd",
    "",
    50000000
  ]
}
<= qtum RPC response
{
  "error": null,
  "id": "1",
  "result": {
    "address": "1d670185fc3f7f3ee9008ce4966e9bad8f780b39",
    "executionResult": {
      "codeDeposit": 0,
      "depositSize": 0,
      "excepted": "BlockGasLimitReached",
      "exceptedMessage": "",
      "gasForDeposit": 0,
      "gasRefunded": 0,
      "gasUsed": 50000000,
      "newAddress": "1d670185fc3f7f3ee9008ce4966e9bad8f780b39",
      "output": ""
    },
    "transactionReceipt": {
      "bloom": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
      "gasUsed": 50000000,
      "log": [],
      "stateRoot": "4dcfbefa1fd142d5c2c89f51da28160c8cc35817901478483e4b364dda1984e9",
      "utxoRoot": "fb4e64e526fa825947a6b6500aa54a81ddca96db4ac353d6c3cddba8a53b538a"
    }
  }
}
level=debug component=qtum.Client function=CallContract request="[\"1d670185fc3f7f3ee9008ce4966e9bad8f780b39\",\"18160ddd\",\"\",50000000]" msg="Successfully called contract"
Internalservererror=null
level=debug msg="ETH RPC"
=> ETH request
{
  "id": 1325,
  "jsonrpc": "2.0",
  "method": "eth_call",
  "params": [
    {
      "data": "0x18160ddd",
      "gas": "0x2faf080",
      "to": "0x1d670185fc3f7f3ee9008ce4966e9bad8f780b39"
    },
    "0xa9529"
  ]
}
<= ETH response
{
  "error": {
    "code": -32000,
    "message": "Revert: executionResult output is empty"
  },
  "id": 1325,
  "jsonrpc": "2.0"
}
```
- Janus behaviour after fix (gasLimit=50M)

```
msg="proxy RPC" method=eth_call
component=qtum.Client msg="Caller gas above allowance, capping" requested=50000000 cap=40,000,000
level=debug msg="ETH RPC"
=> ETH request
{
  "id": 1325,
  "jsonrpc": "2.0",
  "method": "eth_call",
  "params": [
    {
      "data": "0x18160ddd",
      "gas": "0x2faf080",
      "to": "0x1d670185fc3f7f3ee9008ce4966e9bad8f780b39"
    },
    "0xa9529"
  ]
}
<= ETH response
{
  "id": 1325,
  "jsonrpc": "2.0",
  "result": "0x"
}

```

**3. Fix: Hex format validation on block number**

**reference RPC call**
```
  {
    "id": 1,
    "jsonrpc": "2.0",
    "method":"eth_getLogs",
    "params":[{
        "address" : "0x284937a9f5a1d28268d4e48d5eda03b04a7a1786",
        "fromBlock": "731010",
        "toBlock": "732009"
    }]
  }
```
- Janus behaviour before the fix (output received in Postman)
```
{
    "jsonrpc": "2.0",
    "result": [],
    "id": 1
}
```
- Janus behaviour after the fix (output received in Postman)
```
{
    "jsonrpc": "2.0",
    "error": {
        "code": 100,
        "message": "quantity values must start with 0x"
    },
    "id": 1
}
```
