### PR TITLE
fix bug in eth_subscribe with 0x prefix and bug in unit test for agen…

### DIFF
--- a/pkg/internal/tests_common.go
+++ b/pkg/internal/tests_common.go
@@ -423,7 +423,7 @@ func QtumWaitForLogsEntry(log qtum.Log) qtum.WaitForLogsEntry {
 		To:                GetTransactionByHashResponseData.To,
 		CumulativeGasUsed: hexutil.MustDecodeUint64(GetTransactionByHashResponseData.Gas),
 		GasUsed:           hexutil.MustDecodeUint64(GetTransactionByHashResponseData.Gas),
-		ContractAddress:   GetTransactionByHashResponseData.To,
+		ContractAddress:   strings.TrimPrefix(GetTransactionByHashResponseData.To, "0x"),
 		Topics:            log.Topics,
 		Data:              log.Data,
 	}

--- a/pkg/notifier/subscription.go
+++ b/pkg/notifier/subscription.go
@@ -63,8 +63,13 @@ func (s *subscriptionInformation) run() {
 	}
 	stringAddresses := make([]string, len(ethAddresses))
 	for i, ethAddress := range ethAddresses {
-		stringAddresses[i] = ethAddress.String()
+		if strings.HasPrefix(ethAddress.String(), "0x") {
+			stringAddresses[i] = strings.TrimPrefix(ethAddress.String(), "0x")
+		} else {
+			stringAddresses[i] = ethAddress.String()
+		}
 	}
+
 	qtumTopics := qtum.NewSearchLogsTopics(translatedTopics)
 	req := &qtum.WaitForLogsRequest{
 		FromBlock: nextBlock,


### PR DESCRIPTION
# PR description
This PR implement 2 fixes related to bugs when subscribing to events via web3 and the corresponding unit test
## 1. Fix bug in eth_subscribe with "0x" prefix in contract address

### Bug description
A web3 script that subscribes to an ethereum event sends contract address with "0x" prefix, but qtum expects contract address without "0x":

```javascript
level=debug component=qtum.Client method=waitforlogs
=> qtum RPC request
{
"jsonrpc": "1.0",
"method": "waitforlogs",
"id": "1",
"params": [
null,
null,
{
"addresses": [
"0x086edcf3fc8a042c1b174e941187369d2919e06b"
],
"topics": [
"0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9",
null,
null
]
},
0
]
}
<= qtum RPC response
{
"error": {
"code": -32602,
"message": "Invalid hex 160 string"
},
"id": "1",
"result": null
}
```

### Bug fix

In `notifier/subscription.go`:
```golang
	for i, ethAddress := range ethAddresses {
		if strings.HasPrefix(ethAddress.String(), "0x") {
			stringAddresses[i] = strings.TrimPrefix(ethAddress.String(), "0x")
		} else {
			stringAddresses[i] = ethAddress.String()
		}
	}
```
## 2. Fix bug in unit tests for websocket subscription

### Bug description
After implementing fix described above, unit tests fail for web sockets subscription

### Bug fix
The mocked qtum response when testing event subscription should use a contract address without "0x" prefix

`internal/tests_common.go`

```golang
func QtumWaitForLogsEntry(log qtum.Log) qtum.WaitForLogsEntry {
	return qtum.WaitForLogsEntry{
		BlockHash:         GetTransactionByHashBlockHexHash,
		BlockNumber:       GetTransactionByHashBlockNumberInteger,
		TransactionHash:   GetTransactionByHashResponseData.Hash,
		TransactionIndex:  hexutil.MustDecodeUint64(GetTransactionByHashResponseData.TransactionIndex),
		From:              GetTransactionByHashResponseData.From,
		To:                GetTransactionByHashResponseData.To,
		CumulativeGasUsed: hexutil.MustDecodeUint64(GetTransactionByHashResponseData.Gas),
		GasUsed:           hexutil.MustDecodeUint64(GetTransactionByHashResponseData.Gas),
		ContractAddress:   strings.TrimPrefix(GetTransactionByHashResponseData.To, "0x"),
		Topics:            log.Topics,
		Data:              log.Data,
	}
}
```