### PR TITLE
multithreading support

### DIFF
--- a/pkg/qtum/client.go
+++ b/pkg/qtum/client.go
@@ -215,6 +215,8 @@ func (c *Client) do(ctx context.Context, body io.Reader) ([]byte, error) {
 		return nil, err
 	}
 
+	req.Close = true
+
 	resp, err := c.doer.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Bug fixed
Janus/Qtum container eventually run out of available file descriptors in host OS if requests from qtum client are not closed properly