### PR TITLE
fix CalcAmount()

### DIFF
--- a/pkg/qtum/rpc_types.go
+++ b/pkg/qtum/rpc_types.go
@@ -493,10 +493,12 @@ type (
 
 // Calculates transaction total amount of Qtum
 func (resp *DecodedRawTransactionResponse) CalcAmount() decimal.Decimal {
-	var amount decimal.Decimal
+	totalVouts := big.NewFloat(0)
 	for _, out := range resp.Vouts {
-		amount.Add(out.Value)
+		totalVouts = totalVouts.Add(totalVouts, out.Value.BigFloat())
 	}
+	x, _ := totalVouts.Float64()
+	amount := decimal.NewFromFloat(x)
 	return amount
 }
 
@@ -803,10 +805,10 @@ type (
 
 	}
 	RawTransactionVin struct {
-		ID     string  `json:"txid"`
-		VoutN  int64   `json:"vout"`
-		Amount float64 `json:"value"`
-		Address string `json:"address"`
+		ID      string  `json:"txid"`
+		VoutN   int64   `json:"vout"`
+		Amount  float64 `json:"value"`
+		Address string  `json:"address"`
 
 		// Additional fields:
 		// - "scriptSig"

--- a/pkg/qtum/rpc_types.go
+++ b/pkg/qtum/rpc_types.go
@@ -493,12 +493,10 @@ type (
 
 // Calculates transaction total amount of Qtum
 func (resp *DecodedRawTransactionResponse) CalcAmount() decimal.Decimal {
-	totalVouts := big.NewFloat(0)
+	var amount decimal.Decimal
 	for _, out := range resp.Vouts {
-		totalVouts = totalVouts.Add(totalVouts, out.Value.BigFloat())
+		amount = amount.Add(out.Value)
 	}
-	x, _ := totalVouts.Float64()
-	amount := decimal.NewFromFloat(x)
 	return amount
 }
 


### PR DESCRIPTION
## Motivation
function `CalcAmount()` in `rpc_types.go` does not return the correct sum of utxo values
See: https://go.dev/play/p/wRuBJg2uBD1

## Solution
Replaced `add` method from `shopspring/decimal` with `math/big`

## Open questions
N/A