### PR TITLE
Geth subscribe newheads

### DIFF
--- a/pkg/internal/tests_common.go
+++ b/pkg/internal/tests_common.go
@@ -267,6 +267,9 @@ var (
 		To:               "0x0000000000000000000000000000000000000000",
 		Gas:              "0x0",
 		GasPrice:         "0x0",
+		V:                "0x0",
+		R:                "0x0",
+		S:                "0x0",
 	}
 
 	GetTransactionByHashResponse = CreateTransactionByHashResponse()

--- a/pkg/transformer/eth_getTransactionByHash.go
+++ b/pkg/transformer/eth_getTransactionByHash.go
@@ -96,9 +96,10 @@ func getTransactionByHash(p *qtum.Qtum, hash string) (*eth.GetTransactionByHashR
 
 			// TODO: researching
 			// ? Do we need those values
-			V: "",
-			R: "",
-			S: "",
+			//! Added for go-ethereum client support
+			V: "0x0",
+			R: "0x0",
+			S: "0x0",
 
 			Gas:      "0x0",
 			GasPrice: "0x0",
@@ -229,9 +230,10 @@ func getRewardTransactionByHash(p *qtum.Qtum, hash string) (*eth.GetTransactionB
 
 		// TODO: researching
 		// ? Do we need those values
-		V: "",
-		R: "",
-		S: "",
+		//! Added for go-ethereum client support
+		V: "0x0",
+		R: "0x0",
+		S: "0x0",
 	}
 
 	if !rawQtumTx.IsPending() {


### PR DESCRIPTION
# Motivation
go-ethereum client expects response to `eth_transactionByHash` to contain fields `r`, `v`, and `s`

# Solution
Add missing fields `"r"="0x0"`, `"v"="0x0"` and `"s"="0x0"` in tx response

# Open questions
N/A