### PR TITLE
fix that returns empty string when a segwit add is found

### DIFF
--- a/pkg/utils/hex.go
+++ b/pkg/utils/hex.go
@@ -5,7 +5,8 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/decred/base58"
+	"github.com/btcsuite/btcutil/base58"
+	// "github.com/decred/base58"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
@@ -47,8 +48,10 @@ func ConvertQtumAddress(address string) (ethAddress string, _ error) {
 	if n := len(address); n < 22 {
 		return "", errors.Errorf("invalid address: length is less than 22 bytes - %d", n)
 	}
-	if prefix := address[:3]; prefix == "qc1" {
-		return "", errors.Errorf("invalid address: address is Bech32 - %s", prefix)
+
+	_, _, err := base58.CheckDecode(address)
+	if err != nil {
+		return "", errors.Errorf("invalid address")
 	}
 
 	// Drop Qtum chain prefix and checksum suffix

--- a/pkg/utils/hex.go
+++ b/pkg/utils/hex.go
@@ -47,6 +47,9 @@ func ConvertQtumAddress(address string) (ethAddress string, _ error) {
 	if n := len(address); n < 22 {
 		return "", errors.Errorf("invalid address: length is less than 22 bytes - %d", n)
 	}
+	if prefix := address[:3]; prefix == "qc1" {
+		return "", errors.Errorf("invalid address: address is Bech32 - %s", prefix)
+	}
 
 	// Drop Qtum chain prefix and checksum suffix
 	ethAddrBytes := base58.Decode(address)[1:21]

--- a/pkg/utils/hex_test.go
+++ b/pkg/utils/hex_test.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestConvertQtumAddress(t *testing.T) {
+	bech32addressMainnet := "qc1q3422djj7p4mjsgn7m3k3kymd2s36jnrpzcn7xx"
+	bech32addressTestnet := "tq1qxagv83u8vgg656de4aa04xvxe7jfzguwmg020n"
+	legacyaddressMainnet := "QYmyzKNjoox5LkaiUvibZdM252bftQotDx"
+	legacyAddressTesnet := "qUbxboqjBRp96j3La8D1RYkyqx5uQbJPoW"
+
+	var tests = []struct {
+		address string
+		want    string
+		err     error
+	}{
+		{bech32addressMainnet, "", errors.New("invalid address")},
+		{bech32addressTestnet, "", errors.New("invalid address")},
+		{legacyaddressMainnet, "8585918c3ee7168ee9d79dd9b5883eb65d0e0db0", nil},
+		{legacyAddressTesnet, "7926223070547d2d15b2ef5e7383e541c338ffe9", nil},
+	}
+
+	for _, tt := range tests {
+		testname := tt.address
+		t.Run(testname, func(t *testing.T) {
+			got, _ := ConvertQtumAddress(tt.address)
+			if got != tt.want {
+				t.Errorf("got %s, want %s", got, tt.want)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
When calling `eth_getBlockByNumber` on a block that contains a tx with a `segwit` address, Janus will crash

```
echo: http: panic serving 186.108.222.16:61740: runtime error: slice bounds out of range [:21] with capacity 0
goroutine 249173 [running]:
net/http.(*conn).serve.func1(0xc0002620a0)
    /usr/local/go/src/net/http/server.go:1800 +0x139
panic(0xb5ee80, 0xc00014bbe0)
    /usr/local/go/src/runtime/panic.go:975 +0x3e3
github.com/qtumproject/janus/pkg/utils.ConvertQtumAddress(0xc0000c2a20, 0x2a, 0x40, 0x810300, 0xc0004ee000, 0x0)
    /go/src/github.com/qtumproject/janus/pkg/utils/hex.go:52 +0x1b8
```

This fix filters out the `segwit` address and returns an empty string `""`