### PR TITLE
Fixes in ParseCallASM and GetTransactionByHash

### DIFF
--- a/pkg/qtum/btcasm.go
+++ b/pkg/qtum/btcasm.go
@@ -35,12 +35,6 @@ func reversePartToHex(s string) (string, error) {
 func ParseCallASM(parts []string) (*ContractInvokeInfo, error) {
 
 	// "4 25548 40 8588b2c50000000000000000000000000000000000000000000000000000000000000000 57946bb437560b13275c32a468c6fd1e0c2cdd48 OP_CAL"
-	//! For some TXs we get the following with GasPrice and GasLimit in hex:
-	//"4 90d0030000000000 2800000000000000 a9059cbb0000000000000000000000008e60e0b8371c0312cfc703e5e28bc57dfa0674fd0000000000000000000000000000000000000000000000000000000005f5e100 f2703e93f87b846a7aacec1247beaec1c583daa4 OP_CALL"
-
-	if len(parts) != 6 {
-		return nil, errors.New(fmt.Sprintf("invalid OP_CALL script for parts 6: %v", parts))
-	}
 
 	// 4                     // EVM version
 	// 100000                // gas limit
@@ -49,6 +43,13 @@ func ParseCallASM(parts []string) (*ContractInvokeInfo, error) {
 	// Contract Address      // contract address
 	// OP_CALL
 
+	if len(parts) != 6 {
+		return nil, errors.New(fmt.Sprintf("invalid OP_CALL script for parts 6: %v", parts))
+	}
+
+	//! OBS: For some TXs we get the following string with GasPrice and GasLimit in hex:
+	//"4 90d0030000000000 2800000000000000 a9059cbb0000000000000000000000008e60e0b8371c0312cfc703e5e28bc57dfa0674fd0000000000000000000000000000000000000000000000000000000005f5e100 f2703e93f87b846a7aacec1247beaec1c583daa4 OP_CALL"
+	// TODO: temporary solution using func reversePartToHex()
 	gasLimit, err1 := stringBase10ToHex(parts[1])
 	gasPrice, err2 := stringBase10ToHex(parts[2])
 	if err1 != nil || err2 != nil {

--- a/pkg/qtum/btcasm_test.go
+++ b/pkg/qtum/btcasm_test.go
@@ -53,6 +53,37 @@ func TestParseParseCreateSenderASM(t *testing.T) {
 	}
 }
 
+func TestParseCallASM(t *testing.T) {
+	// EVMversion := "4"
+	// gasLimit := "250000"
+	// gasPrice := "40"
+	byteCode := "a9059cbb0000000000000000000000008e60e0b8371c0312cfc703e5e28bc57dfa0674fd0000000000000000000000000000000000000000000000000000000005f5e100"
+	contractAddr := "f2703e93f87b846a7aacec1247beaec1c583daa4"
+	// opcode := "OP_CALL"
+
+	samStr := "4 90d0030000000000 2800000000000000 a9059cbb0000000000000000000000008e60e0b8371c0312cfc703e5e28bc57dfa0674fd0000000000000000000000000000000000000000000000000000000005f5e100 f2703e93f87b846a7aacec1247beaec1c583daa4 OP_CALL"
+
+	got, err := ParseCallASM(strings.Split(samStr, " "))
+	if err != nil {
+		t.Error(err)
+	}
+	want := &ContractInvokeInfo{
+		From:     "",
+		GasLimit: "3d090",
+		GasPrice: "28",
+		CallData: byteCode,
+		To:       contractAddr,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf(
+			"parse transaction call sam error\ninput: %s\nwant: %s\ngot: %s",
+			samStr,
+			string(mustMarshalIndent(want, "", "  ")),
+			string(mustMarshalIndent(got, "", "  ")),
+		)
+	}
+}
+
 func mustMarshalIndent(v interface{}, prefix, indent string) []byte {
 	res, err := json.MarshalIndent(v, prefix, indent)
 	if err != nil {

--- a/pkg/qtum/rpc_types.go
+++ b/pkg/qtum/rpc_types.go
@@ -909,6 +909,8 @@ type (
 		Amount        float64 `json:"value"`
 		AmountSatoshi int64   `json:"valueSat"`
 		Address       string  `json:"address"`
+		// TODO: temporary solution
+		ScriptSig DecodedRawTransactionScriptSig `json:"scriptSig"`
 
 		// Additional fields:
 		// - "scriptSig"

--- a/pkg/transformer/util.go
+++ b/pkg/transformer/util.go
@@ -167,6 +167,7 @@ func getNonContractTxSenderAddress(p *qtum.Qtum, tx *qtum.DecodedRawTransactionR
 		return utils.AddHexPrefix(hexAddress), nil
 	}
 
+	// If we get here, we have no Vins with a valid address, so search for sender address in previous Tx's vouts
 	hexAddr, err := searchSenderAddressInPreviousTransactions(p, rawTx)
 	if err != nil {
 		return "", errors.New("Couldn't find sender address in previous transactions: " + err.Error())
@@ -175,8 +176,9 @@ func getNonContractTxSenderAddress(p *qtum.Qtum, tx *qtum.DecodedRawTransactionR
 	return utils.AddHexPrefix(hexAddr), nil
 }
 
+// Searchs recursively for the sender address in previous transactions
 func searchSenderAddressInPreviousTransactions(p *qtum.Qtum, rawTx *qtum.GetRawTransactionResponse) (string, error) {
-	// search in current rawTx for vin containing opcode OP_SPEND
+	// search within current rawTx for vin containing opcode OP_SPEND
 	var vout int64 = -1
 	var txid string = ""
 	for _, vin := range rawTx.Vins {


### PR DESCRIPTION
Included fixes:

- `/pkg/qtum/btcasm.go > ParseCallASM` now does not error when receiving `gasLimit` and `gasPrice` in hex format

- added support to `OP_SPEND` in `eth_getTransactionByHash`