### PR TITLE
fix bug when gasLimit is zero, in order to support graph-node indexing

### DIFF
--- a/pkg/transformer/eth_getTransactionByHash.go
+++ b/pkg/transformer/eth_getTransactionByHash.go
@@ -166,7 +166,13 @@ func getTransactionByHash(ctx context.Context, p *qtum.Qtum, hash string) (*eth.
 		} else {
 			ethTx.To = utils.AddHexPrefix(qtumTxContractInfo.To)
 		}
+
+		// gasLimit
+		if len(qtumTxContractInfo.GasLimit) == 0 {
+			qtumTxContractInfo.GasLimit = "0"
+		}
 		ethTx.Gas = utils.AddHexPrefix(qtumTxContractInfo.GasLimit)
+
 		// Gas price is in hex satoshis, convert to wei
 		gasPriceInSatoshis, err := utils.DecodeBig(qtumTxContractInfo.GasPrice)
 		if err != nil {

--- a/pkg/transformer/eth_getTransactionByHash_test.go
+++ b/pkg/transformer/eth_getTransactionByHash_test.go
@@ -62,7 +62,7 @@ func TestGetTransactionByHashRequestWithContractVout(t *testing.T) {
 			VoutHex:  "0100010001000100142411fd6feb7c148f58101d0cf6e8c8c45af8f219c2",
 			Input:    "0x00",
 			To:       "0x2411fd6feb7c148f58101d0cf6e8c8c45af8f219",
-			Gas:      "0x",
+			Gas:      "0x0",
 			GasPrice: "0x0",
 		},
 	}

--- a/pkg/transformer/util.go
+++ b/pkg/transformer/util.go
@@ -231,7 +231,7 @@ func searchSenderAddressInPreviousTransactions(ctx context.Context, p *qtum.Qtum
 				return "", errors.WithMessage(err, "couldn't parse call sender ASM")
 			}
 		}
-		return callInfo.From, nil
+		return callInfo.To, nil
 	}
 	return "", errors.New("couldn't find sender address")
 }


### PR DESCRIPTION
graph-node expects no empty `gasLimit` field (i.e. `"0x"`), in the `eth_getTransactionByHash` response
