### PR TITLE
Fixes to vout script parser

### DIFF
--- a/pkg/transformer/eth_getTransactionByHash.go
+++ b/pkg/transformer/eth_getTransactionByHash.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"math/big"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/labstack/echo"
@@ -173,6 +174,11 @@ func getTransactionByHash(ctx context.Context, p *qtum.Qtum, hash string) (*eth.
 		}
 		ethTx.Gas = utils.AddHexPrefix(qtumTxContractInfo.GasLimit)
 
+		// trim leading zeros from gasPrice
+		qtumTxContractInfo.GasPrice = strings.TrimLeft(qtumTxContractInfo.GasPrice, "0")
+		if len(qtumTxContractInfo.GasPrice) == 0 {
+			qtumTxContractInfo.GasPrice = "0"
+		}
 		// Gas price is in hex satoshis, convert to wei
 		gasPriceInSatoshis, err := utils.DecodeBig(qtumTxContractInfo.GasPrice)
 		if err != nil {

--- a/pkg/transformer/eth_getTransactionByHash.go
+++ b/pkg/transformer/eth_getTransactionByHash.go
@@ -139,11 +139,13 @@ func getTransactionByHash(ctx context.Context, p *qtum.Qtum, hash string) (*eth.
 		ethTx.Value = ethAmount
 	}
 
-	qtumTxContractInfo, isContractTx, err := qtumDecodedRawTx.ExtractContractInfo()
-	if err != nil {
-		p.GetDebugLogger().Log("msg", "Couldn't extract contract info", "err", err)
-		return nil, eth.NewCallbackError(qtumTx.Hex /*"couldn't extract contract info"*/)
-	}
+	qtumTxContractInfo, isContractTx, _ := qtumDecodedRawTx.ExtractContractInfo()
+	// parsing err is discarded because it's not an error if the transaction is not a valid contract call
+	// https://testnet.qtum.info/tx/24ed3749022ed21e53d8924764bb0303a4b6fa469f26922bfa64ba44507c4c4a
+	// if err != nil {
+	// 	p.GetDebugLogger().Log("msg", "Couldn't extract contract info", "err", err)
+	// 	return nil, eth.NewCallbackError(qtumTx.Hex /*"couldn't extract contract info"*/)
+	// }
 	if isContractTx {
 		// TODO: research is this allowed? ethTx.Input = utils.AddHexPrefix(qtumTxContractInfo.UserInput)
 		if qtumTxContractInfo.UserInput == "" {


### PR DESCRIPTION
Two new fixes included in `eth_getTransactionByHash`: 
- trimm leading 0 in gasprice before sending response
- discard err returned by script parser in case of malformed script and assume `isContract==false`