### PR TITLE
fix getaddressbalance req type and serialization

### DIFF
--- a/pkg/qtum/rpc_types.go
+++ b/pkg/qtum/rpc_types.go
@@ -1753,7 +1753,7 @@ type (
 		}
 	*/
 	GetAddressBalanceRequest struct {
-		Address string
+		Addresses []string `json:"addresses"`
 	}
 
 	GetAddressBalanceResponse struct {
@@ -1764,8 +1764,8 @@ type (
 )
 
 func (req *GetAddressBalanceRequest) MarshalJSON() ([]byte, error) {
-	params := []interface{}{
-		req.Address,
+	params := []map[string][]string{
+		{"addresses": req.Addresses},
 	}
 	return json.Marshal(params)
 }

--- a/pkg/transformer/eth_getBalance.go
+++ b/pkg/transformer/eth_getBalance.go
@@ -48,7 +48,9 @@ func (p *ProxyETHGetBalance) Request(rawreq *eth.JSONRPCRequest, c echo.Context)
 			return nil, eth.NewCallbackError(err.Error())
 		}
 
-		qtumreq := qtum.GetAddressBalanceRequest{Address: base58Addr}
+		qtumreq := qtum.GetAddressBalanceRequest{
+			Addresses: []string{base58Addr},
+		}
 		qtumresp, err := p.GetAddressBalance(c.Request().Context(), &qtumreq)
 		if err != nil {
 			if err == qtum.ErrInvalidAddress {


### PR DESCRIPTION
This PR implements a fix that modifies how the `eth_getBalance` method interacts with a qtum node.
Specifically, the `params` field for the qtum rpc call `getaddressbalance` is modified from:
```json
"params": ["0x..."]
```
to the format:
```json
"params": [{"addresses":["0x..."]}]
```